### PR TITLE
Issue with size when using BitBuffer.fromBB

### DIFF
--- a/lib/buffer.dart
+++ b/lib/buffer.dart
@@ -40,7 +40,7 @@ int getBitsNeeded(int value) {
 
 class BitBuffer {
   int _size = 0;
-  List<int> _longs = [];
+  final _longs = <int>[];
   Endian endian;
 
   BitBuffer([this.endian = Endian.little]);
@@ -79,8 +79,11 @@ class BitBuffer {
   factory BitBuffer.fromBase64(String compressed, {Endian endian = Endian.little}) =>
       BitBuffer.fromUInt8List(base64Decode(compressed), endian: endian);
 
-  factory BitBuffer.fromBB(BitBuffer obb, {Endian endian = Endian.little}) =>
-      BitBuffer.fromBits(obb.getLongs(), endian: endian, bitsPerIndex: bitsPerInt, trueSize: obb._size);
+  BitBuffer.fromBB(BitBuffer obb, {Endian? endian})
+      : endian = endian ?? obb.endian,
+        _size = obb._size {
+    _longs.addAll(obb._longs);
+  }
 
   factory BitBuffer.fromUInt8List(List<int> bytes, {Endian endian = Endian.little}) =>
       BitBuffer.fromBits(bytes, endian: endian, bitsPerIndex: 8);

--- a/test/bits_test.dart
+++ b/test/bits_test.dart
@@ -238,6 +238,16 @@ void main() {
                 .readSteppedVarInt()),
             reason: 'Failed to writeSteppedVarInt ${i}'));
   }
+
+  test('Test BitBuffer.fromBB - expect copied Buffer to have same size', () {
+    final buffer = BitBuffer();
+    buffer.writer()..writeInt(0x12345678)..writeInt(0x87654321);
+
+    final buffer2 = BitBuffer.fromBB(buffer);
+    expect(buffer2.getSize(), equals(buffer.getSize()));
+    expect(buffer2.endian, equals(buffer.endian));
+    expect(buffer2.getLongs(), equals(buffer.getLongs()));
+  });
 }
 
 Iterable<int> randomInts(int count) sync* {


### PR DESCRIPTION
This pull request includes a change to the `fromBB` constructor in the `BitBuffer` class and adds a new test case.
The most important changes include modifying the `BitBuffer.fromBB` factory constructor, optimizing the `_longs` list initialization, and adding a unit test to ensure the copied buffer has the same properties as the original.

Changes to `BitBuffer` class:

* [`lib/buffer.dart`](diffhunk://#diff-1ae921df46f5f616ade32f0a1aba546a6d571a7b3acdc771c56bf5d0cc688050L82-R86): Modified the `BitBuffer.fromBB` factory constructor to use an initializer list, ensuring the endian and size properties are correctly copied from the original buffer.
* [`lib/buffer.dart`](diffhunk://#diff-1ae921df46f5f616ade32f0a1aba546a6d571a7b3acdc771c56bf5d0cc688050L43-R43): Changed the initialization of the `_longs` list to use a final field with a type annotation for better performance and readability.

New unit test:

* [`test/bits_test.dart`](diffhunk://#diff-3cdae2c3a2162192d16e2821446f97a53f9f2a2ea072b291ff04ca576b51d6dbR241-R250): Added a new test case to verify that a `BitBuffer` created using `BitBuffer.fromBB` has the same size, endian, and longs list as the original buffer.