### PR TITLE
feat(BitBufferWriter): writeBuffer(b)

### DIFF
--- a/lib/writer.dart
+++ b/lib/writer.dart
@@ -182,4 +182,13 @@ class BitBufferWriter {
     }
     writeBits(value.abs(), bits);
   }
+
+  void writeBuffer(BitBuffer buffer) {
+    final reader = buffer.reader();
+    for (int i = 0; i < buffer.getSize();) {
+      final read = min(buffer.getSize() - i, 64);
+      writeBits(reader.readBits(read), read);
+      i += read;
+    }
+  }
 }

--- a/lib/writer.dart
+++ b/lib/writer.dart
@@ -183,10 +183,13 @@ class BitBufferWriter {
     writeBits(value.abs(), bits);
   }
 
-  void writeBuffer(BitBuffer buffer) {
+  void writeBuffer(BitBuffer buffer, {int skip = 0, int? limit}) {
+    final size = min(buffer.getSize(), limit ?? buffer.getSize());
     final reader = buffer.reader();
-    for (int i = 0; i < buffer.getSize();) {
-      final read = min(buffer.getSize() - i, 64);
+    reader.seekTo(skip);
+
+    for (int i = skip; i < size;) {
+      final read = min(size - i, 64);
       writeBits(reader.readBits(read), read);
       i += read;
     }

--- a/test/bits_test.dart
+++ b/test/bits_test.dart
@@ -241,7 +241,9 @@ void main() {
 
   test('Test BitBuffer.fromBB - expect copied Buffer to have same size', () {
     final buffer = BitBuffer();
-    buffer.writer()..writeInt(0x12345678)..writeInt(0x87654321);
+    buffer.writer()
+      ..writeInt(0x12345678)
+      ..writeInt(0x87654321);
 
     final buffer2 = BitBuffer.fromBB(buffer);
     expect(buffer2.getSize(), equals(buffer.getSize()));
@@ -249,18 +251,75 @@ void main() {
     expect(buffer2.getLongs(), equals(buffer.getLongs()));
   });
 
-  test('Test BitBufferWriter.writeBuffer', () {
-    final buffer = BitBuffer();
-    buffer.writer()..writeInt(0x12345678)..writeInt(0x87654321);
+  group('BitBufferWriter.writeBuffer', () {
+    test('Test BitBufferWriter.writeBuffer', () {
+      final buffer = BitBuffer();
+      buffer.writer()
+        ..writeInt(0x12345678)
+        ..writeInt(0x87654321);
 
-    final buffer2 = BitBuffer();
-    buffer2.writer()..writeInt(0x347865, bits: 42)..writeBuffer(buffer);
+      final buffer2 = BitBuffer();
+      buffer2.writer()
+        ..writeInt(0x347865, bits: 42)
+        ..writeBuffer(buffer);
 
-    final reader = buffer2.reader();
-    expect(reader.readInt(bits: 42), equals(0x347865));
-    expect(reader.readInt(), equals(0x12345678));
-    expect(reader.readInt(), equals(0x87654321));
-    expect(buffer2.getSize(), equals(43 + 65 + 65));
+      final reader = buffer2.reader();
+      expect(reader.readInt(bits: 42), equals(0x347865));
+      expect(reader.readInt(), equals(0x12345678));
+      expect(reader.readInt(), equals(0x87654321));
+      expect(buffer2.getSize(), equals(43 + 65 + 65));
+    });
+
+    test('writeBuffer writes entire buffer when no limit is set', () {
+      final sourceBuffer = BitBuffer();
+      final writer = BitBufferWriter(sourceBuffer);
+      writer.writeInt(12345, bits: 32);
+      writer.writeDouble(123.456, bits: 64);
+
+      final targetBuffer = BitBuffer();
+      final targetWriter = BitBufferWriter(targetBuffer);
+      targetWriter.writeBuffer(sourceBuffer);
+
+      final reader = targetBuffer.reader();
+      expect(reader.readInt(bits: 32), 12345);
+      expect(reader.readDouble(bits: 64), 123.456);
+    });
+
+    test('writeBuffer skips initial bytes when skip is set', () {
+      final sourceBuffer = BitBuffer();
+      final writer = BitBufferWriter(sourceBuffer);
+      writer.writeInt(12345, bits: 32, signed: false);
+      writer.writeDouble(123.456, bits: 64, signed: false);
+
+      final targetBuffer = BitBuffer();
+      final targetWriter = BitBufferWriter(targetBuffer);
+      targetWriter.writeBuffer(sourceBuffer, skip: 32);
+
+      final reader = targetBuffer.reader();
+      expect(reader.readDouble(bits: 64, signed: false), 123.456);
+    });
+
+    test('writeBuffer respects limit when set', () {
+      final sourceBuffer = BitBuffer();
+      sourceBuffer.writer()
+        ..writeInt(12345, bits: 32, signed: false)
+        ..writeDouble(123.456, bits: 64, signed: false);
+
+      final targetBuffer = BitBuffer();
+      targetBuffer.writer().writeBuffer(sourceBuffer, limit: 32);
+
+      final reader = targetBuffer.reader();
+      expect(reader.readInt(bits: 32, signed: false), 12345);
+      expect(() => reader.readDouble(bits: 64), throwsRangeError);
+    });
+
+    test('writeBuffer handles empty buffer', () {
+      final sourceBuffer = BitBuffer();
+      final targetBuffer = BitBuffer();
+
+      targetBuffer.writer().writeBuffer(sourceBuffer);
+      expect(targetBuffer.getSize(), 0);
+    });
   });
 }
 

--- a/test/bits_test.dart
+++ b/test/bits_test.dart
@@ -238,6 +238,20 @@ void main() {
                 .readSteppedVarInt()),
             reason: 'Failed to writeSteppedVarInt ${i}'));
   }
+
+  test('Test BitBufferWriter.writeBuffer', () {
+    final buffer = BitBuffer();
+    buffer.writer()..writeInt(0x12345678)..writeInt(0x87654321);
+
+    final buffer2 = BitBuffer();
+    buffer2.writer()..writeInt(0x347865, bits: 42)..writeBuffer(buffer);
+
+    final reader = buffer2.reader();
+    expect(reader.readInt(bits: 42), equals(0x347865));
+    expect(reader.readInt(), equals(0x12345678));
+    expect(reader.readInt(), equals(0x87654321));
+    expect(buffer2.getSize(), equals(43 + 65 + 65));
+  });
 }
 
 Iterable<int> randomInts(int count) sync* {


### PR DESCRIPTION
This pull request adds a new method to the `BitBufferWriter` class and includes a corresponding test to ensure its functionality. The most important changes include the addition of the `writeBuffer` method and the new test case in `bits_test.dart`.

Enhancements to `BitBufferWriter`:

* [`lib/writer.dart`](diffhunk://#diff-6d883a8d16bec06a91565fa5523545ee6adef455d700ddbf7e49d8d6e066eeb0R185-R193): Added the `writeBuffer` method to the `BitBufferWriter` class, which writes the contents of another `BitBuffer` to the current buffer.

Testing improvements:

* [`test/bits_test.dart`](diffhunk://#diff-3cdae2c3a2162192d16e2821446f97a53f9f2a2ea072b291ff04ca576b51d6dbR251-R264): Added a new test case to verify the functionality of the `writeBuffer` method in the `BitBufferWriter` class. The test checks that the buffer contents are correctly written and read back.