### PR TITLE
Testing codecs and refactor codecs for const objects and static fields - suggestion for testing in CI (Actions with optional test-coverage)

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -27,5 +27,5 @@ jobs:
           dart pub global activate coverage
 
           echo "Running full test suite and uploading coverage..."
-          dart test --coverage
+          dart pub global run coverage:test_with_coverage --branch-coverage --function-coverage
           bash <(curl -s https://codecov.io/bash) -t ${{ secrets.CODECOV_TOKEN }} -f ./coverage/lcov.info -F all_tests

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,31 @@
+name: Coverage
+
+on:
+  push:
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: dart-lang/setup-dart@v1
+
+      - name: Install dependencies
+        run: dart pub get
+
+      - name: Analyze project source
+        run: dart analyze
+
+      - name: Run and upload coverage for all tests
+        run: |
+          set -e
+          dart pub global activate coverage
+
+          echo "Running full test suite and uploading coverage..."
+          dart test --coverage
+          bash <(curl -s https://codecov.io/bash) -t ${{ secrets.CODECOV_TOKEN }} -f ./coverage/lcov.info -F all_tests

--- a/lib/codec.dart
+++ b/lib/codec.dart
@@ -125,11 +125,10 @@ BitCodec<dynamic> codec_any = BestBitCodec(codecs: [
   forceAcceptCodec<dynamic>(codec_json_string)
 ]);
 
-BitCodec<dynamic> forceAcceptCodec<T>(BitCodec<T> codec) {
-  return BitCodec(
-      writer: (writer, t) => writer.writeCodec(codec, t as T),
-      reader: (reader) => reader.readCodec(codec) as T);
-}
+BitCodec<dynamic> forceAcceptCodec<T>(BitCodec<T> codec) => BitCodec(
+      writer: (writer, t) => writer.writeCodec(codec, t),
+      reader: (reader) => reader.readCodec(codec),
+    );
 
 typedef BitCodecWriter<T> = void Function(BitBufferWriter writer, T t);
 typedef BitCodecReader<T> = T Function(BitBufferReader reader);

--- a/lib/codec.dart
+++ b/lib/codec.dart
@@ -325,36 +325,30 @@ class BestBitCodec<T> implements BitCodec<T> {
 
     return BestBitCodec(codecs: [...codecs, codec]);
   }
-}
 
-int getBestCodec<T>(List<BitCodec<T>> codecs, T value) {
-  int smallest = -1;
-  int bestCodec = -1;
+  static int getBestCodec<T>(List<BitCodec<T>> codecs, T value) {
+    int bestCodec = -1;
+    int smallest = -1;
 
-  for (int i = 0; i < codecs.length; i++) {
-    int size = getCodecWrittenSize(codecs[i], value);
-
-    if (size < 0) {
-      continue;
+    for (int i = 0; i < codecs.length; i++) {
+      int size = getCodecWrittenSize(codecs[i], value);
+      if (size >= 0 && (smallest == -1 || size < smallest)) {
+        smallest = size;
+        bestCodec = i;
+      }
     }
 
-    if (smallest == -1 || size < smallest) {
-      smallest = size;
-      bestCodec = i;
+    if (bestCodec == -1) throw Exception("No codec could write $value");
+
+    return bestCodec;
+  }
+
+  static int getCodecWrittenSize<T>(BitCodec<T> codec, T value) {
+    try {
+      return (DummyBitBufferWriter()..writeCodec(codec, value))
+          .getBitsWritten();
+    } catch (e) {
+      return -1;
     }
-  }
-
-  if (bestCodec == -1) {
-    throw Exception("No codec could write $value");
-  }
-
-  return bestCodec;
-}
-
-int getCodecWrittenSize<T>(BitCodec<T> method, T value) {
-  try {
-    return (DummyBitBufferWriter()..writeCodec(method, value)).getBitsWritten();
-  } catch (e) {
-    return -1;
   }
 }

--- a/lib/codec.dart
+++ b/lib/codec.dart
@@ -21,8 +21,11 @@ abstract class BitCodec<T> {
   static void _stringCompressedWrite(BitBufferWriter w, String t) =>
       w.writeSteppedVarString(compress(t));
 
-  static String _stringCompressedRead(BitBufferReader r) =>
-      decompress(r.readSteppedVarString());
+  static String _stringCompressedRead(BitBufferReader r) {
+    final compressed = r.readSteppedVarString();
+    if (compressed.isEmpty) return '';
+    return decompress(compressed);
+  }
 
   static const stringStepped = SimpleBitCodec<String>(
     writer: _stringSteppedWrite,

--- a/lib/codec.dart
+++ b/lib/codec.dart
@@ -13,262 +13,258 @@ abstract class BitCodec<T> {
 
   BitCodec<T> variant(BitCodec<T> codec);
 
-  static const codec_string_compressed = SimpleBitCodec<String>(
-    writer: _string_compressed_write,
-    reader: _string_compressed_read,
+  static const stringCompressed = SimpleBitCodec<String>(
+    writer: _stringCompressedWrite,
+    reader: _stringCompressedRead,
   );
 
-  static void _string_compressed_write(BitBufferWriter w, String t) =>
+  static void _stringCompressedWrite(BitBufferWriter w, String t) =>
       w.writeSteppedVarString(compress(t));
 
-  static String _string_compressed_read(BitBufferReader r) =>
+  static String _stringCompressedRead(BitBufferReader r) =>
       decompress(r.readSteppedVarString());
 
-  static const codec_string_stepped = SimpleBitCodec<String>(
-    writer: _string_stepped_write,
-    reader: _string_stepped_read,
+  static const stringStepped = SimpleBitCodec<String>(
+    writer: _stringSteppedWrite,
+    reader: _stringSteppedRead,
   );
 
-  static void _string_stepped_write(BitBufferWriter w, String t) =>
+  static void _stringSteppedWrite(BitBufferWriter w, String t) =>
       w.writeSteppedVarString(t);
 
-  static String _string_stepped_read(BitBufferReader r) =>
+  static String _stringSteppedRead(BitBufferReader r) =>
       r.readSteppedVarString();
 
-  static const codec_string_linear = SimpleBitCodec<String>(
-    writer: _string_linear_write,
-    reader: _string_linear_read,
+  static const stringLinear = SimpleBitCodec<String>(
+    writer: _stringLinearWrite,
+    reader: _stringLinearRead,
   );
 
-  static void _string_linear_write(BitBufferWriter w, String t) =>
+  static void _stringLinearWrite(BitBufferWriter w, String t) =>
       w.writeLinearVarString(t);
 
-  static String _string_linear_read(BitBufferReader r) =>
-      r.readLinearVarString();
+  static String _stringLinearRead(BitBufferReader r) => r.readLinearVarString();
 
-  static const codec_stepped_utf16 = SimpleBitCodec<int>(
-    writer: _stepped_utf16_write,
-    reader: _stepped_utf16_read,
+  static const steppedUtf16 = SimpleBitCodec<int>(
+    writer: _steppedUtf16Write,
+    reader: _steppedUtf16Read,
   );
 
-  static void _stepped_utf16_write(BitBufferWriter w, int t) =>
+  static void _steppedUtf16Write(BitBufferWriter w, int t) =>
       w.writeSteppedVarInt(t, signed: false, bitLimits: stepCharList1b);
 
-  static int _stepped_utf16_read(BitBufferReader r) =>
+  static int _steppedUtf16Read(BitBufferReader r) =>
       r.readSteppedVarInt(signed: false, bitLimits: stepCharList1b);
 
-  static BitCodec<String> codec_string_palette = SimpleBitCodec<String>(
-    writer: _string_palette_write,
-    reader: _string_palette_read,
+  static BitCodec<String> stringPalette = SimpleBitCodec<String>(
+    writer: _stringPaletteWrite,
+    reader: _stringPaletteRead,
   );
 
-  static void _string_palette_write(BitBufferWriter w, String t) {
-    PaletteData<int> palette = PaletteData<int>(codec: codec_stepped_utf16);
+  static void _stringPaletteWrite(BitBufferWriter w, String t) {
+    PaletteData<int> palette = PaletteData<int>(codec: steppedUtf16);
     t.codeUnits.forEach((c) => palette.write(c));
     palette.toBitBuffer(w);
   }
 
-  static String _string_palette_read(BitBufferReader r) {
-    PaletteData<int> palette = PaletteData<int>.fromBitBufferReader(
-        codec: codec_stepped_utf16, reader: r);
+  static String _stringPaletteRead(BitBufferReader r) {
+    PaletteData<int> palette =
+        PaletteData<int>.fromBitBufferReader(codec: steppedUtf16, reader: r);
     return palette.getAllData().map((e) => String.fromCharCode(e)).join();
   }
 
-  static const codec_string_best = BestBitCodec<String>(codecs: [
-    codec_string_compressed,
-    codec_string_stepped,
+  static const stringBest = BestBitCodec<String>(codecs: [
+    stringCompressed,
+    stringStepped,
   ]);
 
-  static const codec_int_stepped_4_low = SimpleBitCodec<int>(
-    writer: _int_stepped_4_low_write,
-    reader: _int_stepped_4_low_read,
+  static const intStepped4Low = SimpleBitCodec<int>(
+    writer: _intStepped4LowWrite,
+    reader: _intStepped4LowRead,
   );
 
-  static void _int_stepped_4_low_write(BitBufferWriter w, int t) =>
+  static void _intStepped4LowWrite(BitBufferWriter w, int t) =>
       w.writeSteppedVarInt(t, bitLimits: stepIntLow4_16);
 
-  static int _int_stepped_4_low_read(BitBufferReader r) =>
+  static int _intStepped4LowRead(BitBufferReader r) =>
       r.readSteppedVarInt(bitLimits: stepIntLow4_16);
 
-  static const codec_int_linear_8 = SimpleBitCodec<int>(
-    writer: _int_linear_8_write,
-    reader: _int_linear_8_read,
+  static const intLinear8 = SimpleBitCodec<int>(
+    writer: _intLinear8Write,
+    reader: _intLinear8Read,
   );
 
-  static void _int_linear_8_write(BitBufferWriter w, int t) =>
+  static void _intLinear8Write(BitBufferWriter w, int t) =>
       w.writeLinearVarInt(t, maxBits: 8);
 
-  static int _int_linear_8_read(BitBufferReader r) =>
+  static int _intLinear8Read(BitBufferReader r) =>
       r.readLinearVarInt(maxBits: 8);
 
-  static const codec_int_linear_16 = SimpleBitCodec<int>(
-    writer: _int_linear_16_write,
-    reader: _int_linear_16_read,
+  static const intLinear16 = SimpleBitCodec<int>(
+    writer: _intLinear16Write,
+    reader: _intLinear16Read,
   );
 
-  static void _int_linear_16_write(BitBufferWriter w, int t) =>
+  static void _intLinear16Write(BitBufferWriter w, int t) =>
       w.writeLinearVarInt(t, maxBits: 16);
 
-  static int _int_linear_16_read(BitBufferReader r) =>
+  static int _intLinear16Read(BitBufferReader r) =>
       r.readLinearVarInt(maxBits: 16);
 
-  static const codec_int_linear_64 = SimpleBitCodec<int>(
-    writer: _int_linear_64_write,
-    reader: _int_linear_64_read,
+  static const intLinear64 = SimpleBitCodec<int>(
+    writer: _intLinear64Write,
+    reader: _intLinear64Read,
   );
 
-  static void _int_linear_64_write(BitBufferWriter w, int t) =>
+  static void _intLinear64Write(BitBufferWriter w, int t) =>
       w.writeLinearVarInt(t);
 
-  static int _int_linear_64_read(BitBufferReader r) => r.readLinearVarInt();
+  static int _intLinear64Read(BitBufferReader r) => r.readLinearVarInt();
 
-  static const codec_int_best = BestBitCodec<int>(codecs: [
-    codec_int_stepped_4_low,
-    codec_int_linear_8,
-    codec_int_linear_16,
-    codec_int_linear_64,
+  static const intBest = BestBitCodec<int>(codecs: [
+    intStepped4Low,
+    intLinear8,
+    intLinear16,
+    intLinear64,
   ]);
 
-  static const codec_double_stepped_4_low = SimpleBitCodec<double>(
-    writer: _double_stepped_4_low_write,
-    reader: _double_stepped_4_low_read,
+  static const doubleStepped4Low = SimpleBitCodec<double>(
+    writer: _doubleStepped4LowWrite,
+    reader: _doubleStepped4LowRead,
   );
 
-  static void _double_stepped_4_low_write(BitBufferWriter w, double t) =>
+  static void _doubleStepped4LowWrite(BitBufferWriter w, double t) =>
       w.writeSteppedVarDouble(t, bitLimits: stepIntLow4_16);
 
-  static double _double_stepped_4_low_read(BitBufferReader r) =>
+  static double _doubleStepped4LowRead(BitBufferReader r) =>
       r.readSteppedVarDouble(bitLimits: stepIntLow4_16);
 
-  static const codec_double_linear_8 = SimpleBitCodec<double>(
-    writer: _double_linear_8_write,
-    reader: _double_linear_8_read,
+  static const doubleLinear8 = SimpleBitCodec<double>(
+    writer: _doubleLinear8Write,
+    reader: _doubleLinear8Read,
   );
 
-  static void _double_linear_8_write(BitBufferWriter w, double t) =>
+  static void _doubleLinear8Write(BitBufferWriter w, double t) =>
       w.writeLinearVarDouble(t, maxBits: 8);
 
-  static double _double_linear_8_read(BitBufferReader r) =>
+  static double _doubleLinear8Read(BitBufferReader r) =>
       r.readLinearVarDouble(maxBits: 8);
 
-  static const codec_double_linear_16 = SimpleBitCodec<double>(
-    writer: _double_linear_16_write,
-    reader: _double_linear_16_read,
+  static const doubleLinear16 = SimpleBitCodec<double>(
+    writer: _doubleLinear16Write,
+    reader: _doubleLinear16Read,
   );
 
-  static void _double_linear_16_write(BitBufferWriter w, double t) =>
+  static void _doubleLinear16Write(BitBufferWriter w, double t) =>
       w.writeLinearVarDouble(t, maxBits: 16);
 
-  static double _double_linear_16_read(BitBufferReader r) =>
+  static double _doubleLinear16Read(BitBufferReader r) =>
       r.readLinearVarDouble(maxBits: 16);
 
-  static const codec_double_linear_64 = SimpleBitCodec<double>(
-    writer: _double_linear_64_write,
-    reader: _double_linear_64_read,
+  static const doubleLinear64 = SimpleBitCodec<double>(
+    writer: _doubleLinear64Write,
+    reader: _doubleLinear64Read,
   );
 
-  static void _double_linear_64_write(BitBufferWriter w, double t) =>
+  static void _doubleLinear64Write(BitBufferWriter w, double t) =>
       w.writeLinearVarDouble(t);
 
-  static double _double_linear_64_read(BitBufferReader r) =>
+  static double _doubleLinear64Read(BitBufferReader r) =>
       r.readLinearVarDouble();
 
-  static const codec_double_best = BestBitCodec<double>(codecs: [
-    codec_double_stepped_4_low,
-    codec_double_linear_8,
-    codec_double_linear_16,
-    codec_double_linear_64
+  static const doubleBest = BestBitCodec<double>(codecs: [
+    doubleStepped4Low,
+    doubleLinear8,
+    doubleLinear16,
+    doubleLinear64
   ]);
 
-  static const codec_list = SimpleBitCodec(
-    writer: _list_write,
-    reader: _list_read,
+  static const list = SimpleBitCodec(
+    writer: _listWrite,
+    reader: _listRead,
   );
 
-  static void _list_write(BitBufferWriter w, List<dynamic> t) {
-    w.writeCodec(codec_int_best, t.length);
-    t.forEach((e) => w.writeCodec(codec_any, e));
+  static void _listWrite(BitBufferWriter w, List<dynamic> t) {
+    w.writeCodec(intBest, t.length);
+    t.forEach((e) => w.writeCodec(any, e));
   }
 
-  static List<dynamic> _list_read(BitBufferReader r) {
-    int length = r.readCodec(codec_int_best);
+  static List<dynamic> _listRead(BitBufferReader r) {
+    int length = r.readCodec(intBest);
     List<dynamic> list = <dynamic>[];
     for (int i = 0; i < length; i++) {
-      list.add(r.readCodec(codec_any));
+      list.add(r.readCodec(any));
     }
     return list;
   }
 
-  static const codec_string_map = SimpleBitCodec(
-    writer: _string_map_write,
-    reader: _string_map_read,
+  static const stringMap = SimpleBitCodec(
+    writer: _stringMapWrite,
+    reader: _stringMapRead,
   );
 
-  static void _string_map_write(BitBufferWriter w, Map<String, dynamic> t) {
-    w.writeCodec(codec_int_best, t.length);
+  static void _stringMapWrite(BitBufferWriter w, Map<String, dynamic> t) {
+    w.writeCodec(intBest, t.length);
     t.forEach((key, value) {
-      w.writeCodec(codec_string_best, key);
-      w.writeCodec(codec_any, value);
+      w.writeCodec(stringBest, key);
+      w.writeCodec(any, value);
     });
   }
 
-  static Map<String, dynamic> _string_map_read(BitBufferReader r) {
-    int length = r.readCodec(codec_int_best);
+  static Map<String, dynamic> _stringMapRead(BitBufferReader r) {
+    int length = r.readCodec(intBest);
     Map<String, dynamic> map = <String, dynamic>{};
     for (int i = 0; i < length; i++) {
-      map[r.readCodec(codec_string_best)] = r.readCodec(codec_any);
+      map[r.readCodec(stringBest)] = r.readCodec(any);
     }
     return map;
   }
 
-  static const codec_json = BestBitCodec<Map<String, dynamic>>(
-    codecs: [codec_json_string_map, codec_string_map],
+  static const json = BestBitCodec<Map<String, dynamic>>(
+    codecs: [jsonStringMap, stringMap],
   );
 
-  static const codec_bool = SimpleBitCodec(
-    writer: _bool_write,
-    reader: _bool_read,
+  static const boolean = SimpleBitCodec(
+    writer: _boolWrite,
+    reader: _boolRead,
   );
 
-  static void _bool_write(BitBufferWriter w, bool t) => w.writeBit(t);
+  static void _boolWrite(BitBufferWriter w, bool t) => w.writeBit(t);
 
-  static bool _bool_read(BitBufferReader r) => r.readBit();
+  static bool _boolRead(BitBufferReader r) => r.readBit();
 
-  static const codec_json_string = SimpleBitCodec<dynamic>(
-    writer: _json_string_write,
-    reader: _json_string_read,
+  static const jsonString = SimpleBitCodec<dynamic>(
+    writer: _jsonStringWrite,
+    reader: _jsonStringRead,
   );
 
-  static void _json_string_write(BitBufferWriter w, dynamic t) {
-    w.writeCodec(codec_string_best, jsonEncode(t));
+  static void _jsonStringWrite(BitBufferWriter w, dynamic t) {
+    w.writeCodec(stringBest, jsonEncode(t));
   }
 
-  static dynamic _json_string_read(BitBufferReader r) {
-    return jsonDecode(r.readCodec(codec_string_best));
+  static dynamic _jsonStringRead(BitBufferReader r) {
+    return jsonDecode(r.readCodec(stringBest));
   }
 
-  static const codec_json_string_map = SimpleBitCodec<Map<String, dynamic>>(
-    writer: _json_string_map_write,
-    reader: _json_string_map_read,
+  static const jsonStringMap = SimpleBitCodec<Map<String, dynamic>>(
+    writer: _jsonStringMapWrite,
+    reader: _jsonStringMapRead,
   );
 
-  static void _json_string_map_write(
-      BitBufferWriter w, Map<String, dynamic> t) {
-    w.writeCodec(codec_string_best, jsonEncode(t));
-  }
+  static void _jsonStringMapWrite(BitBufferWriter w, Map<String, dynamic> t) =>
+      w.writeCodec(stringBest, jsonEncode(t));
 
-  static Map<String, dynamic> _json_string_map_read(BitBufferReader r) {
-    return jsonDecode(r.readCodec(codec_string_best));
-  }
+  static Map<String, dynamic> _jsonStringMapRead(BitBufferReader r) =>
+      jsonDecode(r.readCodec(stringBest));
 
-  static const codec_any = BestBitCodec(codecs: [
-    RWBitCodec<String>(codec: codec_string_best),
-    RWBitCodec<bool>(codec: codec_bool),
-    RWBitCodec<int>(codec: codec_int_best),
-    RWBitCodec<double>(codec: codec_double_best),
-    RWBitCodec<List<dynamic>>(codec: codec_list),
-    RWBitCodec<Map<String, dynamic>>(codec: codec_string_map),
-    RWBitCodec<dynamic>(codec: codec_json_string)
+  static const any = BestBitCodec(codecs: [
+    RWBitCodec<String>(codec: stringBest),
+    RWBitCodec<bool>(codec: boolean),
+    RWBitCodec<int>(codec: intBest),
+    RWBitCodec<double>(codec: doubleBest),
+    RWBitCodec<List<dynamic>>(codec: list),
+    RWBitCodec<Map<String, dynamic>>(codec: stringMap),
+    RWBitCodec<dynamic>(codec: jsonString)
   ]);
 }
 

--- a/lib/codec.dart
+++ b/lib/codec.dart
@@ -63,7 +63,7 @@ abstract class BitCodec<T> {
 
   static void _stringPaletteWrite(BitBufferWriter w, String t) {
     PaletteData<int> palette = PaletteData<int>(codec: steppedUtf16);
-    t.codeUnits.forEach((c) => palette.write(c));
+    t.codeUnits.forEach(palette.write);
     palette.toBitBuffer(w);
   }
 
@@ -186,7 +186,9 @@ abstract class BitCodec<T> {
 
   static void _listWrite(BitBufferWriter w, List<dynamic> t) {
     w.writeCodec(intBest, t.length);
-    t.forEach((e) => w.writeCodec(any, e));
+    for (var e in t) {
+      w.writeCodec(any, e);
+    }
   }
 
   static List<dynamic> _listRead(BitBufferReader r) {
@@ -293,10 +295,13 @@ class SimpleBitCodec<T> implements BitCodec<T> {
   final BitCodecWriter<T> _writer;
   final BitCodecReader<T> _reader;
 
+  @override
   void writer(BitBufferWriter writer, T t) => _writer(writer, t);
 
+  @override
   T reader(BitBufferReader reader) => _reader(reader);
 
+  @override
   BitCodec<T> variant(BitCodec<T> codec) => BestBitCodec(codecs: [this, codec]);
 }
 

--- a/lib/codec.dart
+++ b/lib/codec.dart
@@ -3,158 +3,287 @@ import 'dart:convert';
 import 'package:bits/bits.dart';
 import 'package:threshold/threshold.dart';
 
-BitCodec<String> codec_string_compressed = BitCodec<String>(
-    writer: (w, t) => w.writeSteppedVarString(compress(t)),
-    reader: (r) => decompress(r.readSteppedVarString()));
-BitCodec<String> codec_string_stepped = BitCodec<String>(
-    writer: (w, t) => w.writeSteppedVarString(t),
-    reader: (r) => r.readSteppedVarString());
-BitCodec<String> codec_string_linear = BitCodec<String>(
-    writer: (w, t) => w.writeLinearVarString(t),
-    reader: (r) => r.readLinearVarString());
-BitCodec<int> codec_stepped_utf16 = BitCodec<int>(
-    writer: (w, t) =>
-        w.writeSteppedVarInt(t, signed: false, bitLimits: stepCharList1b),
-    reader: (r) =>
-        r.readSteppedVarInt(signed: false, bitLimits: stepCharList1b));
-BitCodec<String> codec_string_palette = BitCodec<String>(
-    writer: (w, t) {
-      PaletteData<int> palette = PaletteData<int>(codec: codec_stepped_utf16);
-      t.codeUnits.forEach((c) => palette.write(c));
-      palette.toBitBuffer(w);
-    },
-    reader: (r) =>
-        PaletteData.fromBitBufferReader(codec: codec_stepped_utf16, reader: r)
-            .getAllData()
-            .map((e) => String.fromCharCode(e))
-            .join());
-BitCodec<String> codec_string_best = BestBitCodec<String>(codecs: [
-  codec_string_compressed,
-  codec_string_stepped,
-]);
-
-BitCodec<int> codec_int_stepped_4_low = BitCodec<int>(
-    writer: (w, t) => w.writeSteppedVarInt(t, bitLimits: stepIntLow4_16),
-    reader: (r) => r.readSteppedVarInt(bitLimits: stepIntLow4_16));
-BitCodec<int> codec_int_linear_8 = BitCodec<int>(
-    writer: (w, t) => w.writeLinearVarInt(t, maxBits: 8),
-    reader: (r) => r.readLinearVarInt(maxBits: 8));
-BitCodec<int> codec_int_linear_16 = BitCodec<int>(
-    writer: (w, t) => w.writeLinearVarInt(t, maxBits: 16),
-    reader: (r) => r.readLinearVarInt(maxBits: 16));
-BitCodec<int> codec_int_linear_64 = BitCodec<int>(
-    writer: (w, t) => w.writeLinearVarInt(t),
-    reader: (r) => r.readLinearVarInt());
-BitCodec<int> codec_int_best = BestBitCodec<int>(codecs: [
-  codec_int_stepped_4_low,
-  codec_int_linear_8,
-  codec_int_linear_16,
-  codec_int_linear_64
-]);
-
-BitCodec<double> codec_double_stepped_4_low = BitCodec<double>(
-    writer: (w, t) => w.writeSteppedVarDouble(t, bitLimits: stepIntLow4_16),
-    reader: (r) => r.readSteppedVarDouble(bitLimits: stepIntLow4_16));
-BitCodec<double> codec_double_linear_8 = BitCodec<double>(
-    writer: (w, t) => w.writeLinearVarDouble(t, maxBits: 8),
-    reader: (r) => r.readLinearVarDouble(maxBits: 8));
-BitCodec<double> codec_double_linear_16 = BitCodec<double>(
-    writer: (w, t) => w.writeLinearVarDouble(t, maxBits: 16),
-    reader: (r) => r.readLinearVarDouble(maxBits: 16));
-BitCodec<double> codec_double_linear_64 = BitCodec<double>(
-    writer: (w, t) => w.writeLinearVarDouble(t),
-    reader: (r) => r.readLinearVarDouble());
-BitCodec<double> codec_double_best = BestBitCodec<double>(codecs: [
-  codec_double_stepped_4_low,
-  codec_double_linear_8,
-  codec_double_linear_16,
-  codec_double_linear_64
-]);
-
-BitCodec<List<dynamic>> codec_list = BitCodec(writer: (writer, t) {
-  writer.writeCodec(codec_int_best, t.length);
-  t.forEach((e) => writer.writeCodec(codec_any, e));
-}, reader: (reader) {
-  int length = reader.readCodec(codec_int_best);
-  List<dynamic> list = <dynamic>[];
-  for (int i = 0; i < length; i++) {
-    list.add(reader.readCodec(codec_any));
-  }
-  return list;
-});
-
-BitCodec<Map<String, dynamic>> codec_string_map = BitCodec(writer: (writer, t) {
-  writer.writeCodec(codec_int_best, t.length);
-  t.forEach((key, value) {
-    writer.writeCodec(codec_string_best, key);
-    writer.writeCodec(codec_any, value);
-  });
-}, reader: (reader) {
-  int length = reader.readCodec(codec_int_best);
-  Map<String, dynamic> map = <String, dynamic>{};
-  for (int i = 0; i < length; i++) {
-    map[reader.readCodec(codec_string_best)] = reader.readCodec(codec_any);
-  }
-  return map;
-});
-
-BitCodec<Map<String, dynamic>> codec_json = BestBitCodec<Map<String, dynamic>>(
-    codecs: [codec_json_string_map, codec_string_map]);
-
-BitCodec<bool> codec_bool = BitCodec(
-    writer: (writer, t) => writer.writeBit(t),
-    reader: (reader) => reader.readBit());
-
-BitCodec<dynamic> codec_json_string = BitCodec<dynamic>(
-    writer: (writer, t) => writer.writeCodec(codec_string_best, jsonEncode(t)),
-    reader: (reader) => jsonDecode(reader.readCodec(codec_string_best)));
-
-BitCodec<Map<String, dynamic>> codec_json_string_map =
-    BitCodec<Map<String, dynamic>>(
-        writer: (writer, t) =>
-            writer.writeCodec(codec_string_best, jsonEncode(t)),
-        reader: (reader) => jsonDecode(reader.readCodec(codec_string_best)));
-
-BitCodec<dynamic> codec_any = BestBitCodec(codecs: [
-  forceAcceptCodec<String>(codec_string_best),
-  forceAcceptCodec<bool>(codec_bool),
-  forceAcceptCodec<int>(codec_int_best),
-  forceAcceptCodec<double>(codec_double_best),
-  forceAcceptCodec<List<dynamic>>(codec_list),
-  forceAcceptCodec<Map<String, dynamic>>(codec_string_map),
-  forceAcceptCodec<dynamic>(codec_json_string)
-]);
-
-BitCodec<dynamic> forceAcceptCodec<T>(BitCodec<T> codec) => BitCodec(
-      writer: (writer, t) => writer.writeCodec(codec, t),
-      reader: (reader) => reader.readCodec(codec),
-    );
-
 typedef BitCodecWriter<T> = void Function(BitBufferWriter writer, T t);
 typedef BitCodecReader<T> = T Function(BitBufferReader reader);
 
-class BitCodec<T> {
-  final BitCodecWriter<T> writer;
-  final BitCodecReader<T> reader;
+abstract class BitCodec<T> {
+  void writer(BitBufferWriter writer, T t);
 
-  BitCodec({required this.writer, required this.reader});
+  T reader(BitBufferReader reader);
+
+  BitCodec<T> variant(BitCodec<T> codec);
+
+  static const codec_string_compressed = SingleBitCodec<String>(
+    writer: _string_compressed_write,
+    reader: _string_compressed_read,
+  );
+
+  static void _string_compressed_write(BitBufferWriter w, String t) =>
+      w.writeSteppedVarString(compress(t));
+
+  static String _string_compressed_read(BitBufferReader r) =>
+      decompress(r.readSteppedVarString());
+
+  static const codec_string_stepped = SingleBitCodec<String>(
+    writer: _string_stepped_write,
+    reader: _string_stepped_read,
+  );
+
+  static void _string_stepped_write(BitBufferWriter w, String t) =>
+      w.writeSteppedVarString(t);
+
+  static String _string_stepped_read(BitBufferReader r) =>
+      r.readSteppedVarString();
+
+  static const codec_string_linear = SingleBitCodec<String>(
+    writer: _string_linear_write,
+    reader: _string_linear_read,
+  );
+
+  static void _string_linear_write(BitBufferWriter w, String t) =>
+      w.writeLinearVarString(t);
+
+  static String _string_linear_read(BitBufferReader r) =>
+      r.readLinearVarString();
+
+  static const codec_stepped_utf16 = SingleBitCodec<int>(
+    writer: _stepped_utf16_write,
+    reader: _stepped_utf16_read,
+  );
+
+  static void _stepped_utf16_write(BitBufferWriter w, int t) =>
+      w.writeSteppedVarInt(t, signed: false, bitLimits: stepCharList1b);
+
+  static int _stepped_utf16_read(BitBufferReader r) =>
+      r.readSteppedVarInt(signed: false, bitLimits: stepCharList1b);
+
+  static BitCodec<String> codec_string_palette = SingleBitCodec<String>(
+    writer: _string_palette_write,
+    reader: _string_palette_read,
+  );
+
+  static void _string_palette_write(BitBufferWriter w, String t) {
+    PaletteData<int> palette = PaletteData<int>(codec: codec_stepped_utf16);
+    t.codeUnits.forEach((c) => palette.write(c));
+    palette.toBitBuffer(w);
+  }
+
+  static String _string_palette_read(BitBufferReader r) {
+    PaletteData<int> palette = PaletteData<int>.fromBitBufferReader(
+        codec: codec_stepped_utf16, reader: r);
+    return palette.getAllData().map((e) => String.fromCharCode(e)).join();
+  }
+
+  static const codec_string_best = BestBitCodec<String>(codecs: [
+    codec_string_compressed,
+    codec_string_stepped,
+  ]);
+
+  static const codec_int_stepped_4_low = SingleBitCodec<int>(
+    writer: _int_stepped_4_low_write,
+    reader: _int_stepped_4_low_read,
+  );
+
+  static void _int_stepped_4_low_write(BitBufferWriter w, int t) =>
+      w.writeSteppedVarInt(t, bitLimits: stepIntLow4_16);
+
+  static int _int_stepped_4_low_read(BitBufferReader r) =>
+      r.readSteppedVarInt(bitLimits: stepIntLow4_16);
+
+  static const codec_int_linear_8 = SingleBitCodec<int>(
+    writer: _int_linear_8_write,
+    reader: _int_linear_8_read,
+  );
+
+  static void _int_linear_8_write(BitBufferWriter w, int t) =>
+      w.writeLinearVarInt(t, maxBits: 8);
+
+  static int _int_linear_8_read(BitBufferReader r) =>
+      r.readLinearVarInt(maxBits: 8);
+
+  static const codec_int_linear_16 = SingleBitCodec<int>(
+    writer: _int_linear_16_write,
+    reader: _int_linear_16_read,
+  );
+
+  static void _int_linear_16_write(BitBufferWriter w, int t) =>
+      w.writeLinearVarInt(t, maxBits: 16);
+
+  static int _int_linear_16_read(BitBufferReader r) =>
+      r.readLinearVarInt(maxBits: 16);
+
+  static const codec_int_linear_64 = SingleBitCodec<int>(
+    writer: _int_linear_64_write,
+    reader: _int_linear_64_read,
+  );
+
+  static void _int_linear_64_write(BitBufferWriter w, int t) =>
+      w.writeLinearVarInt(t);
+
+  static int _int_linear_64_read(BitBufferReader r) => r.readLinearVarInt();
+
+  static const codec_int_best = BestBitCodec<int>(codecs: [
+    codec_int_stepped_4_low,
+    codec_int_linear_8,
+    codec_int_linear_16,
+    codec_int_linear_64,
+  ]);
+
+  static const codec_double_stepped_4_low = SingleBitCodec<double>(
+    writer: _double_stepped_4_low_write,
+    reader: _double_stepped_4_low_read,
+  );
+
+  static void _double_stepped_4_low_write(BitBufferWriter w, double t) =>
+      w.writeSteppedVarDouble(t, bitLimits: stepIntLow4_16);
+
+  static double _double_stepped_4_low_read(BitBufferReader r) =>
+      r.readSteppedVarDouble(bitLimits: stepIntLow4_16);
+
+  static const codec_double_linear_8 = SingleBitCodec<double>(
+    writer: _double_linear_8_write,
+    reader: _double_linear_8_read,
+  );
+
+  static void _double_linear_8_write(BitBufferWriter w, double t) =>
+      w.writeLinearVarDouble(t, maxBits: 8);
+
+  static double _double_linear_8_read(BitBufferReader r) =>
+      r.readLinearVarDouble(maxBits: 8);
+
+  static const codec_double_linear_16 = SingleBitCodec<double>(
+    writer: _double_linear_16_write,
+    reader: _double_linear_16_read,
+  );
+
+  static void _double_linear_16_write(BitBufferWriter w, double t) =>
+      w.writeLinearVarDouble(t, maxBits: 16);
+
+  static double _double_linear_16_read(BitBufferReader r) =>
+      r.readLinearVarDouble(maxBits: 16);
+
+  static const codec_double_linear_64 = SingleBitCodec<double>(
+    writer: _double_linear_64_write,
+    reader: _double_linear_64_read,
+  );
+
+  static void _double_linear_64_write(BitBufferWriter w, double t) =>
+      w.writeLinearVarDouble(t);
+
+  static double _double_linear_64_read(BitBufferReader r) =>
+      r.readLinearVarDouble();
+
+  static const codec_double_best = BestBitCodec<double>(codecs: [
+    codec_double_stepped_4_low,
+    codec_double_linear_8,
+    codec_double_linear_16,
+    codec_double_linear_64
+  ]);
+
+  static BitCodec<List<dynamic>> codec_list = SingleBitCodec(
+    writer: (writer, t) {
+      writer.writeCodec(codec_int_best, t.length);
+      t.forEach((e) => writer.writeCodec(codec_any, e));
+    },
+    reader: (reader) {
+      int length = reader.readCodec(codec_int_best);
+      List<dynamic> list = <dynamic>[];
+      for (int i = 0; i < length; i++) {
+        list.add(reader.readCodec(codec_any));
+      }
+      return list;
+    },
+  );
+
+  static BitCodec<Map<String, dynamic>> codec_string_map = SingleBitCodec(
+    writer: (writer, t) {
+      writer.writeCodec(codec_int_best, t.length);
+      t.forEach((key, value) {
+        writer.writeCodec(codec_string_best, key);
+        writer.writeCodec(codec_any, value);
+      });
+    },
+    reader: (reader) {
+      int length = reader.readCodec(codec_int_best);
+      Map<String, dynamic> map = <String, dynamic>{};
+      for (int i = 0; i < length; i++) {
+        map[reader.readCodec(codec_string_best)] = reader.readCodec(codec_any);
+      }
+      return map;
+    },
+  );
+
+  static BitCodec<Map<String, dynamic>> codec_json =
+      BestBitCodec<Map<String, dynamic>>(
+    codecs: [codec_json_string_map, codec_string_map],
+  );
+
+  static BitCodec<bool> codec_bool = SingleBitCodec(
+    writer: (writer, t) => writer.writeBit(t),
+    reader: (reader) => reader.readBit(),
+  );
+
+  static BitCodec<dynamic> codec_json_string = SingleBitCodec<dynamic>(
+    writer: (writer, t) => writer.writeCodec(codec_string_best, jsonEncode(t)),
+    reader: (reader) => jsonDecode(reader.readCodec(codec_string_best)),
+  );
+
+  static BitCodec<Map<String, dynamic>> codec_json_string_map =
+      SingleBitCodec<Map<String, dynamic>>(
+    writer: (writer, t) => writer.writeCodec(codec_string_best, jsonEncode(t)),
+    reader: (reader) => jsonDecode(reader.readCodec(codec_string_best)),
+  );
+
+  static BitCodec<dynamic> codec_any = BestBitCodec(codecs: [
+    forceAcceptCodec<String>(codec_string_best),
+    forceAcceptCodec<bool>(codec_bool),
+    forceAcceptCodec<int>(codec_int_best),
+    forceAcceptCodec<double>(codec_double_best),
+    forceAcceptCodec<List<dynamic>>(codec_list),
+    forceAcceptCodec<Map<String, dynamic>>(codec_string_map),
+    forceAcceptCodec<dynamic>(codec_json_string)
+  ]);
+
+  static SingleBitCodec<dynamic> forceAcceptCodec<T>(BitCodec<T> codec) =>
+      SingleBitCodec(
+        writer: (writer, t) => writer.writeCodec(codec, t),
+        reader: (reader) => reader.readCodec(codec),
+      );
+}
+
+class SingleBitCodec<T> implements BitCodec<T> {
+  const SingleBitCodec({
+    required BitCodecWriter<T> writer,
+    required BitCodecReader<T> reader,
+  })  : _writer = writer,
+        _reader = reader;
+
+  final BitCodecWriter<T> _writer;
+  final BitCodecReader<T> _reader;
+
+  void writer(BitBufferWriter writer, T t) => _writer(writer, t);
+
+  T reader(BitBufferReader reader) => _reader(reader);
 
   BitCodec<T> variant(BitCodec<T> codec) => BestBitCodec(codecs: [this, codec]);
 }
 
-class BestBitCodec<T> extends BitCodec<T> {
+class BestBitCodec<T> implements BitCodec<T> {
   final List<BitCodec<T>> codecs;
 
-  BestBitCodec({required this.codecs})
-      : super(
-            writer: (buf, d) {
-              int bestCodec = getBestCodec(codecs, d);
-              buf.writeInt(bestCodec,
-                  signed: false, bits: getBitsNeeded(codecs.length - 1));
-              buf.writeCodec(codecs[bestCodec], d);
-            },
-            reader: (buf) => buf.readCodec(codecs[buf.readInt(
-                signed: false, bits: getBitsNeeded(codecs.length - 1))]));
+  const BestBitCodec({required this.codecs});
+
+  @override
+  void writer(BitBufferWriter writer, T t) {
+    int bestCodec = getBestCodec(codecs, t);
+    writer.writeInt(bestCodec,
+        signed: false, bits: getBitsNeeded(codecs.length - 1));
+    writer.writeCodec(codecs[bestCodec], t);
+  }
+
+  @override
+  T reader(BitBufferReader reader) => reader.readCodec(codecs[
+      reader.readInt(signed: false, bits: getBitsNeeded(codecs.length - 1))]);
 
   @override
   BestBitCodec<T> variant(BitCodec<T> codec) {

--- a/lib/codec.dart
+++ b/lib/codec.dart
@@ -13,7 +13,7 @@ abstract class BitCodec<T> {
 
   BitCodec<T> variant(BitCodec<T> codec);
 
-  static const codec_string_compressed = SingleBitCodec<String>(
+  static const codec_string_compressed = SimpleBitCodec<String>(
     writer: _string_compressed_write,
     reader: _string_compressed_read,
   );
@@ -24,7 +24,7 @@ abstract class BitCodec<T> {
   static String _string_compressed_read(BitBufferReader r) =>
       decompress(r.readSteppedVarString());
 
-  static const codec_string_stepped = SingleBitCodec<String>(
+  static const codec_string_stepped = SimpleBitCodec<String>(
     writer: _string_stepped_write,
     reader: _string_stepped_read,
   );
@@ -35,7 +35,7 @@ abstract class BitCodec<T> {
   static String _string_stepped_read(BitBufferReader r) =>
       r.readSteppedVarString();
 
-  static const codec_string_linear = SingleBitCodec<String>(
+  static const codec_string_linear = SimpleBitCodec<String>(
     writer: _string_linear_write,
     reader: _string_linear_read,
   );
@@ -46,7 +46,7 @@ abstract class BitCodec<T> {
   static String _string_linear_read(BitBufferReader r) =>
       r.readLinearVarString();
 
-  static const codec_stepped_utf16 = SingleBitCodec<int>(
+  static const codec_stepped_utf16 = SimpleBitCodec<int>(
     writer: _stepped_utf16_write,
     reader: _stepped_utf16_read,
   );
@@ -57,7 +57,7 @@ abstract class BitCodec<T> {
   static int _stepped_utf16_read(BitBufferReader r) =>
       r.readSteppedVarInt(signed: false, bitLimits: stepCharList1b);
 
-  static BitCodec<String> codec_string_palette = SingleBitCodec<String>(
+  static BitCodec<String> codec_string_palette = SimpleBitCodec<String>(
     writer: _string_palette_write,
     reader: _string_palette_read,
   );
@@ -79,7 +79,7 @@ abstract class BitCodec<T> {
     codec_string_stepped,
   ]);
 
-  static const codec_int_stepped_4_low = SingleBitCodec<int>(
+  static const codec_int_stepped_4_low = SimpleBitCodec<int>(
     writer: _int_stepped_4_low_write,
     reader: _int_stepped_4_low_read,
   );
@@ -90,7 +90,7 @@ abstract class BitCodec<T> {
   static int _int_stepped_4_low_read(BitBufferReader r) =>
       r.readSteppedVarInt(bitLimits: stepIntLow4_16);
 
-  static const codec_int_linear_8 = SingleBitCodec<int>(
+  static const codec_int_linear_8 = SimpleBitCodec<int>(
     writer: _int_linear_8_write,
     reader: _int_linear_8_read,
   );
@@ -101,7 +101,7 @@ abstract class BitCodec<T> {
   static int _int_linear_8_read(BitBufferReader r) =>
       r.readLinearVarInt(maxBits: 8);
 
-  static const codec_int_linear_16 = SingleBitCodec<int>(
+  static const codec_int_linear_16 = SimpleBitCodec<int>(
     writer: _int_linear_16_write,
     reader: _int_linear_16_read,
   );
@@ -112,7 +112,7 @@ abstract class BitCodec<T> {
   static int _int_linear_16_read(BitBufferReader r) =>
       r.readLinearVarInt(maxBits: 16);
 
-  static const codec_int_linear_64 = SingleBitCodec<int>(
+  static const codec_int_linear_64 = SimpleBitCodec<int>(
     writer: _int_linear_64_write,
     reader: _int_linear_64_read,
   );
@@ -129,7 +129,7 @@ abstract class BitCodec<T> {
     codec_int_linear_64,
   ]);
 
-  static const codec_double_stepped_4_low = SingleBitCodec<double>(
+  static const codec_double_stepped_4_low = SimpleBitCodec<double>(
     writer: _double_stepped_4_low_write,
     reader: _double_stepped_4_low_read,
   );
@@ -140,7 +140,7 @@ abstract class BitCodec<T> {
   static double _double_stepped_4_low_read(BitBufferReader r) =>
       r.readSteppedVarDouble(bitLimits: stepIntLow4_16);
 
-  static const codec_double_linear_8 = SingleBitCodec<double>(
+  static const codec_double_linear_8 = SimpleBitCodec<double>(
     writer: _double_linear_8_write,
     reader: _double_linear_8_read,
   );
@@ -151,7 +151,7 @@ abstract class BitCodec<T> {
   static double _double_linear_8_read(BitBufferReader r) =>
       r.readLinearVarDouble(maxBits: 8);
 
-  static const codec_double_linear_16 = SingleBitCodec<double>(
+  static const codec_double_linear_16 = SimpleBitCodec<double>(
     writer: _double_linear_16_write,
     reader: _double_linear_16_read,
   );
@@ -162,7 +162,7 @@ abstract class BitCodec<T> {
   static double _double_linear_16_read(BitBufferReader r) =>
       r.readLinearVarDouble(maxBits: 16);
 
-  static const codec_double_linear_64 = SingleBitCodec<double>(
+  static const codec_double_linear_64 = SimpleBitCodec<double>(
     writer: _double_linear_64_write,
     reader: _double_linear_64_read,
   );
@@ -180,7 +180,7 @@ abstract class BitCodec<T> {
     codec_double_linear_64
   ]);
 
-  static const codec_list = SingleBitCodec(
+  static const codec_list = SimpleBitCodec(
     writer: _list_write,
     reader: _list_read,
   );
@@ -199,7 +199,7 @@ abstract class BitCodec<T> {
     return list;
   }
 
-  static const codec_string_map = SingleBitCodec(
+  static const codec_string_map = SimpleBitCodec(
     writer: _string_map_write,
     reader: _string_map_read,
   );
@@ -225,7 +225,7 @@ abstract class BitCodec<T> {
     codecs: [codec_json_string_map, codec_string_map],
   );
 
-  static const codec_bool = SingleBitCodec(
+  static const codec_bool = SimpleBitCodec(
     writer: _bool_write,
     reader: _bool_read,
   );
@@ -234,7 +234,7 @@ abstract class BitCodec<T> {
 
   static bool _bool_read(BitBufferReader r) => r.readBit();
 
-  static const codec_json_string = SingleBitCodec<dynamic>(
+  static const codec_json_string = SimpleBitCodec<dynamic>(
     writer: _json_string_write,
     reader: _json_string_read,
   );
@@ -247,7 +247,7 @@ abstract class BitCodec<T> {
     return jsonDecode(r.readCodec(codec_string_best));
   }
 
-  static const codec_json_string_map = SingleBitCodec<Map<String, dynamic>>(
+  static const codec_json_string_map = SimpleBitCodec<Map<String, dynamic>>(
     writer: _json_string_map_write,
     reader: _json_string_map_read,
   );
@@ -287,8 +287,8 @@ class RWBitCodec<T> implements BitCodec<T> {
   BitCodec<T> variant(BitCodec<T> codec) => BestBitCodec(codecs: [this, codec]);
 }
 
-class SingleBitCodec<T> implements BitCodec<T> {
-  const SingleBitCodec({
+class SimpleBitCodec<T> implements BitCodec<T> {
+  const SimpleBitCodec({
     required BitCodecWriter<T> writer,
     required BitCodecReader<T> reader,
   })  : _writer = writer,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,10 +2,15 @@ name: bits
 description: Write in bits instead of bytes for packing data tighter, and increasing headaches.
 version: 1.3.4
 homepage: https://github.com/ArcaneArts/bits
+
 environment:
   sdk: '>=2.18.6 <3.0.0'
+
 dependencies:
   crypto: ">=3.0.2 <=3.1.0"
   threshold: ">=1.0.3 <=1.1.0"
+
 dev_dependencies:
+  flutter_lints: ^5.0.0
   test: ^1.25.14
+  very_good_analysis: ^7.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,4 +13,3 @@ dependencies:
 dev_dependencies:
   flutter_lints: ^5.0.0
   test: ^1.25.14
-  very_good_analysis: ^7.0.0

--- a/test/bits_test.dart
+++ b/test/bits_test.dart
@@ -52,7 +52,7 @@ void main() {
       "a",
       "c"
     ];
-    BitCodec<String> codec = SingleBitCodec<String>(
+    BitCodec<String> codec = SimpleBitCodec<String>(
       writer: (BitBufferWriter writer, String t) => writer.writeString(t),
       reader: (BitBufferReader reader) => reader.readString(),
     );

--- a/test/bits_test.dart
+++ b/test/bits_test.dart
@@ -52,9 +52,11 @@ void main() {
       "a",
       "c"
     ];
-    BitCodec<String> codec = BitCodec<String>(
-        writer: (BitBufferWriter writer, String t) => writer.writeString(t),
-        reader: (BitBufferReader reader) => reader.readString());
+    BitCodec<String> codec = SingleBitCodec<String>(
+      writer: (BitBufferWriter writer, String t) => writer.writeString(t),
+      reader: (BitBufferReader reader) => reader.readString(),
+    );
+
     PaletteData<String> p = PaletteData<String>(codec: codec);
     data.forEach((e) => p.write(e));
     BitBuffer buffer = p.toBitBuffer();

--- a/test/codec_test.dart
+++ b/test/codec_test.dart
@@ -157,4 +157,132 @@ void main() {
       expect(writer.getBitsWritten(), 134);
     });
   });
+
+  group('Backwards Codec Compatibility', () {
+    test('codec_string_compressed decodes correctly', () {
+      final buffer = BitBuffer.fromBits([100059283527975748, 293721599081145], trueSize: 114);
+      final result = codec_string_compressed.reader(buffer.reader());
+
+      expect(result, 'Hello, World!');
+    });
+
+    test('codec_string_stepped decodes correctly', () {
+      final buffer = BitBuffer.fromBits([100059283527975748, 293721599081145], trueSize: 114);
+      final result = codec_string_stepped.reader(buffer.reader());
+
+      expect(result, 'Hello, World!');
+    });
+
+    test('codec_string_linear decodes correctly', () {
+      final buffer = BitBuffer.fromBits([-6962012935230841020, -1982173524448681545, 17830542727], trueSize: 163);
+      final result = codec_string_linear.reader(buffer.reader());
+
+      expect(result, 'Hello, World!');
+    });
+
+    test('codec_stepped_utf16 decodes correctly', () {
+      final buffer = BitBuffer.fromBits([24691], trueSize: 17);
+      final result = codec_stepped_utf16.reader(buffer.reader());
+
+      expect(result, 12345);
+    });
+
+    test('codec_string_palette decodes correctly', () {
+      final buffer = BitBuffer.fromBits([6665522876794609988, -8119263838298861111, 2629752564971], trueSize: 170);
+      final result = codec_string_palette.reader(buffer.reader());
+
+      expect(result, 'Hello, World!');
+    });
+
+    test('codec_int_linear_8 decodes correctly', () {
+      final buffer = BitBuffer.fromBits([3959], trueSize: 12);
+      final result = codec_int_linear_8.reader(buffer.reader());
+
+      expect(result, 123);
+    });
+
+    test('codec_int_linear_16 decodes correctly', () {
+      final buffer = BitBuffer.fromBits([790126], trueSize: 20);
+      final result = codec_int_linear_16.reader(buffer.reader());
+
+      expect(result, 12345);
+    });
+
+    test('codec_int_linear_64 decodes correctly', () {
+      final buffer = BitBuffer.fromBits([31604938139], trueSize: 35);
+      final result = codec_int_linear_64.reader(buffer.reader());
+
+      expect(result, 123456789);
+    });
+
+    test('codec_double_linear_8 decodes correctly', () {
+      final buffer = BitBuffer.fromBits([765041063513967], trueSize: 50);
+      final result = codec_double_linear_8.reader(buffer.reader());
+
+      expect(result, 123.456);
+    });
+
+    test('codec_double_linear_16 decodes correctly', () {
+      final buffer = BitBuffer.fromBits([1530082127027919], trueSize: 51);
+      final result = codec_double_linear_16.reader(buffer.reader());
+
+      expect(result, 123.456);
+    });
+
+    test('codec_double_linear_64 decodes correctly', () {
+      final buffer = BitBuffer.fromBits([6120328508111631], trueSize: 53);
+      final result = codec_double_linear_64.reader(buffer.reader());
+
+      expect(result, 123.456);
+    });
+
+    test('codec_list decodes correctly', () {
+      final buffer = BitBuffer.fromBits([-3673361555328330108, 4014455708976232556, 17], trueSize: 134);
+      final result = codec_list.reader(buffer.reader());
+
+      expect(result, [1, 2, 3, 'Hello']);
+    });
+
+    test('codec_string_map decodes correctly', () {
+      final buffer = BitBuffer.fromBits([1240862530166686756, 18909578539195], trueSize: 110);
+      final result = codec_string_map.reader(buffer.reader());
+
+      expect(result, {'key': 'value'});
+    });
+
+    test('codec_json decodes correctly', () {
+      final buffer = BitBuffer.fromBits([2481725060333373513, 37819157078390], trueSize: 111);
+      final result = codec_json.reader(buffer.reader());
+
+      expect(result, {'key': 'value'});
+    });
+
+    test('codec_bool decodes correctly', () {
+      final buffer = BitBuffer.fromBits([1], trueSize: 1);
+      final result = codec_bool.reader(buffer.reader());
+
+      expect(result, true);
+    });
+
+    test('codec_json_string decodes correctly', () {
+      final buffer = BitBuffer.fromBits([-6762271016373209208, -3303857246427454941, 7], trueSize: 131);
+      final result = codec_json_string.reader(buffer.reader());
+
+      expect(result, {'key': 'value'});
+    });
+
+    test('codec_json_string_map decodes correctly', () {
+      final buffer = BitBuffer.fromBits([-6762271016373209208, -3303857246427454941, 7], trueSize: 131);
+      final result = codec_json_string_map.reader(buffer.reader());
+
+      expect(result, {'key': 'value'});
+    });
+
+    test('codec_any decodes correctly', () {
+      final buffer = BitBuffer.fromBits([4014455708976233542, 1203083669836369942, 17], trueSize: 134);
+      final result = codec_any.reader(buffer.reader());
+
+      expect(result, 'Hello, World!');
+    });
+  });
 }

--- a/test/codec_test.dart
+++ b/test/codec_test.dart
@@ -1,0 +1,160 @@
+import 'package:bits/bits.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('BitCodec', () {
+    late BitBuffer buffer;
+    late BitBufferWriter writer;
+    late BitBufferReader reader;
+
+    setUp(() {
+      buffer = BitBuffer();
+      writer = buffer.writer();
+      reader = buffer.reader();
+    });
+
+    test('codec_string_compressed encodes and decodes correctly', () {
+      codec_string_compressed.writer(writer, 'Hello, World!');
+      final result = codec_string_compressed.reader(reader);
+
+      expect(result, 'Hello, World!');
+      expect(writer.getBitsWritten(), 114);
+    });
+
+    test('codec_string_stepped encodes and decodes correctly', () {
+      codec_string_stepped.writer(writer, 'Hello, World!');
+      final result = codec_string_stepped.reader(reader);
+
+      expect(result, 'Hello, World!');
+      expect(writer.getBitsWritten(), 114);
+    });
+
+    test('codec_string_linear encodes and decodes correctly', () {
+      codec_string_linear.writer(writer, 'Hello, World!');
+      final result = codec_string_linear.reader(reader);
+
+      expect(result, 'Hello, World!');
+      expect(writer.getBitsWritten(), 163);
+    });
+
+    test('codec_stepped_utf16 encodes and decodes correctly', () {
+      codec_stepped_utf16.writer(writer, 12345);
+      final result = codec_stepped_utf16.reader(reader);
+
+      expect(result, 12345);
+      expect(writer.getBitsWritten(), 17);
+    });
+
+    test('codec_string_palette encodes and decodes correctly', () {
+      codec_string_palette.writer(writer, 'Hello, World!');
+      final result = codec_string_palette.reader(reader);
+
+      expect(result, 'Hello, World!');
+      expect(writer.getBitsWritten(), 170);
+    });
+
+    test('codec_int_linear_8 encodes and decodes correctly', () {
+      codec_int_linear_8.writer(writer, 123);
+      final result = codec_int_linear_8.reader(reader);
+
+      expect(result, 123);
+      expect(writer.getBitsWritten(), 12);
+    });
+
+    test('codec_int_linear_16 encodes and decodes correctly', () {
+      codec_int_linear_16.writer(writer, 12345);
+      final result = codec_int_linear_16.reader(reader);
+
+      expect(result, 12345);
+      expect(writer.getBitsWritten(), 20);
+    });
+
+    test('codec_int_linear_64 encodes and decodes correctly', () {
+      codec_int_linear_64.writer(writer, 123456789);
+      final result = codec_int_linear_64.reader(reader);
+
+      expect(result, 123456789);
+      expect(writer.getBitsWritten(), 35);
+    });
+
+    test('codec_double_linear_8 encodes and decodes correctly', () {
+      codec_double_linear_8.writer(writer, 123.456);
+      final result = codec_double_linear_8.reader(reader);
+
+      expect(result, 123.456);
+      expect(writer.getBitsWritten(), 50);
+    });
+
+    test('codec_double_linear_16 encodes and decodes correctly', () {
+      codec_double_linear_16.writer(writer, 123.456);
+      final result = codec_double_linear_16.reader(reader);
+
+      expect(result, 123.456);
+      expect(writer.getBitsWritten(), 51);
+    });
+
+    test('codec_double_linear_64 encodes and decodes correctly', () {
+      codec_double_linear_64.writer(writer, 123.456);
+      final result = codec_double_linear_64.reader(reader);
+
+      expect(result, 123.456);
+      expect(writer.getBitsWritten(), 53);
+    });
+
+    test('codec_list encodes and decodes correctly', () {
+      codec_list.writer(writer, [1, 2, 3, 'Hello']);
+      final result = codec_list.reader(reader);
+
+      expect(result, [1, 2, 3, 'Hello']);
+      expect(writer.getBitsWritten(), 134);
+    });
+
+    test('codec_string_map encodes and decodes correctly', () {
+      codec_string_map.writer(writer, {'key': 'value'});
+      final result = codec_string_map.reader(reader);
+
+      expect(result, {'key': 'value'});
+      expect(writer.getBitsWritten(), 110);
+    });
+
+    test('codec_json encodes and decodes correctly', () {
+      codec_json.writer(writer, {'key': 'value'});
+      final result = codec_json.reader(reader);
+
+      expect(result, {'key': 'value'});
+      expect(writer.getBitsWritten(), 111);
+    });
+
+    test('codec_bool encodes and decodes correctly', () {
+      codec_bool.writer(writer, true);
+      final result = codec_bool.reader(reader);
+
+      expect(result, true);
+      expect(writer.getBitsWritten(), 1);
+    });
+
+    test('codec_json_string encodes and decodes correctly', () {
+      codec_json_string.writer(writer, {'key': 'value'});
+      final result = codec_json_string.reader(reader);
+
+      expect(result, {'key': 'value'});
+      expect(writer.getBitsWritten(), 131);
+    });
+
+    test('codec_json_string_map encodes and decodes correctly', () {
+      codec_json_string_map.writer(writer, {'key': 'value'});
+      final result = codec_json_string_map.reader(reader);
+
+      expect(result, {'key': 'value'});
+      expect(writer.getBitsWritten(), 131);
+    });
+
+    test('codec_any encodes and decodes correctly', () {
+      codec_any.writer(writer, 'Hello, World!');
+      final result = codec_any.reader(reader);
+
+      expect(result, 'Hello, World!');
+      expect(writer.getBitsWritten(), 134);
+    });
+  });
+}

--- a/test/codec_test.dart
+++ b/test/codec_test.dart
@@ -14,144 +14,144 @@ void main() {
     });
 
     test('codec_string_compressed encodes and decodes correctly', () {
-      BitCodec.codec_string_compressed.writer(writer, 'Hello, World!');
-      final result = BitCodec.codec_string_compressed.reader(reader);
+      BitCodec.stringCompressed.writer(writer, 'Hello, World!');
+      final result = BitCodec.stringCompressed.reader(reader);
 
       expect(result, 'Hello, World!');
       expect(writer.getBitsWritten(), 114);
     });
 
     test('codec_string_stepped encodes and decodes correctly', () {
-      BitCodec.codec_string_stepped.writer(writer, 'Hello, World!');
-      final result = BitCodec.codec_string_stepped.reader(reader);
+      BitCodec.stringStepped.writer(writer, 'Hello, World!');
+      final result = BitCodec.stringStepped.reader(reader);
 
       expect(result, 'Hello, World!');
       expect(writer.getBitsWritten(), 114);
     });
 
     test('codec_string_linear encodes and decodes correctly', () {
-      BitCodec.codec_string_linear.writer(writer, 'Hello, World!');
-      final result = BitCodec.codec_string_linear.reader(reader);
+      BitCodec.stringLinear.writer(writer, 'Hello, World!');
+      final result = BitCodec.stringLinear.reader(reader);
 
       expect(result, 'Hello, World!');
       expect(writer.getBitsWritten(), 163);
     });
 
     test('codec_stepped_utf16 encodes and decodes correctly', () {
-      BitCodec.codec_stepped_utf16.writer(writer, 12345);
-      final result = BitCodec.codec_stepped_utf16.reader(reader);
+      BitCodec.steppedUtf16.writer(writer, 12345);
+      final result = BitCodec.steppedUtf16.reader(reader);
 
       expect(result, 12345);
       expect(writer.getBitsWritten(), 17);
     });
 
     test('codec_string_palette encodes and decodes correctly', () {
-      BitCodec.codec_string_palette.writer(writer, 'Hello, World!');
-      final result = BitCodec.codec_string_palette.reader(reader);
+      BitCodec.stringPalette.writer(writer, 'Hello, World!');
+      final result = BitCodec.stringPalette.reader(reader);
 
       expect(result, 'Hello, World!');
       expect(writer.getBitsWritten(), 170);
     });
 
     test('codec_int_linear_8 encodes and decodes correctly', () {
-      BitCodec.codec_int_linear_8.writer(writer, 123);
-      final result = BitCodec.codec_int_linear_8.reader(reader);
+      BitCodec.intLinear8.writer(writer, 123);
+      final result = BitCodec.intLinear8.reader(reader);
 
       expect(result, 123);
       expect(writer.getBitsWritten(), 12);
     });
 
     test('codec_int_linear_16 encodes and decodes correctly', () {
-      BitCodec.codec_int_linear_16.writer(writer, 12345);
-      final result = BitCodec.codec_int_linear_16.reader(reader);
+      BitCodec.intLinear16.writer(writer, 12345);
+      final result = BitCodec.intLinear16.reader(reader);
 
       expect(result, 12345);
       expect(writer.getBitsWritten(), 20);
     });
 
     test('codec_int_linear_64 encodes and decodes correctly', () {
-      BitCodec.codec_int_linear_64.writer(writer, 123456789);
-      final result = BitCodec.codec_int_linear_64.reader(reader);
+      BitCodec.intLinear64.writer(writer, 123456789);
+      final result = BitCodec.intLinear64.reader(reader);
 
       expect(result, 123456789);
       expect(writer.getBitsWritten(), 35);
     });
 
     test('codec_double_linear_8 encodes and decodes correctly', () {
-      BitCodec.codec_double_linear_8.writer(writer, 123.456);
-      final result = BitCodec.codec_double_linear_8.reader(reader);
+      BitCodec.doubleLinear8.writer(writer, 123.456);
+      final result = BitCodec.doubleLinear8.reader(reader);
 
       expect(result, 123.456);
       expect(writer.getBitsWritten(), 50);
     });
 
     test('codec_double_linear_16 encodes and decodes correctly', () {
-      BitCodec.codec_double_linear_16.writer(writer, 123.456);
-      final result = BitCodec.codec_double_linear_16.reader(reader);
+      BitCodec.doubleLinear16.writer(writer, 123.456);
+      final result = BitCodec.doubleLinear16.reader(reader);
 
       expect(result, 123.456);
       expect(writer.getBitsWritten(), 51);
     });
 
     test('codec_double_linear_64 encodes and decodes correctly', () {
-      BitCodec.codec_double_linear_64.writer(writer, 123.456);
-      final result = BitCodec.codec_double_linear_64.reader(reader);
+      BitCodec.doubleLinear64.writer(writer, 123.456);
+      final result = BitCodec.doubleLinear64.reader(reader);
 
       expect(result, 123.456);
       expect(writer.getBitsWritten(), 53);
     });
 
     test('codec_list encodes and decodes correctly', () {
-      BitCodec.codec_list.writer(writer, [1, 2, 3, 'Hello']);
-      final result = BitCodec.codec_list.reader(reader);
+      BitCodec.list.writer(writer, [1, 2, 3, 'Hello']);
+      final result = BitCodec.list.reader(reader);
 
       expect(result, [1, 2, 3, 'Hello']);
       expect(writer.getBitsWritten(), 94);
     });
 
     test('codec_string_map encodes and decodes correctly', () {
-      BitCodec.codec_string_map.writer(writer, {'key': 'value'});
-      final result = BitCodec.codec_string_map.reader(reader);
+      BitCodec.stringMap.writer(writer, {'key': 'value'});
+      final result = BitCodec.stringMap.reader(reader);
 
       expect(result, {'key': 'value'});
       expect(writer.getBitsWritten(), 94);
     });
 
     test('codec_json encodes and decodes correctly', () {
-      BitCodec.codec_json.writer(writer, {'key': 'value'});
-      final result = BitCodec.codec_json.reader(reader);
+      BitCodec.json.writer(writer, {'key': 'value'});
+      final result = BitCodec.json.reader(reader);
 
       expect(result, {'key': 'value'});
       expect(writer.getBitsWritten(), 95);
     });
 
     test('codec_bool encodes and decodes correctly', () {
-      BitCodec.codec_bool.writer(writer, true);
-      final result = BitCodec.codec_bool.reader(reader);
+      BitCodec.boolean.writer(writer, true);
+      final result = BitCodec.boolean.reader(reader);
 
       expect(result, true);
       expect(writer.getBitsWritten(), 1);
     });
 
     test('codec_json_string encodes and decodes correctly', () {
-      BitCodec.codec_json_string.writer(writer, {'key': 'value'});
-      final result = BitCodec.codec_json_string.reader(reader);
+      BitCodec.jsonString.writer(writer, {'key': 'value'});
+      final result = BitCodec.jsonString.reader(reader);
 
       expect(result, {'key': 'value'});
       expect(writer.getBitsWritten(), 131);
     });
 
     test('codec_json_string_map encodes and decodes correctly', () {
-      BitCodec.codec_json_string_map.writer(writer, {'key': 'value'});
-      final result = BitCodec.codec_json_string_map.reader(reader);
+      BitCodec.jsonStringMap.writer(writer, {'key': 'value'});
+      final result = BitCodec.jsonStringMap.reader(reader);
 
       expect(result, {'key': 'value'});
       expect(writer.getBitsWritten(), 131);
     });
 
     test('codec_any encodes and decodes correctly', () {
-      BitCodec.codec_any.writer(writer, 'Hello, World!');
-      final result = BitCodec.codec_any.reader(reader);
+      BitCodec.any.writer(writer, 'Hello, World!');
+      final result = BitCodec.any.reader(reader);
 
       expect(result, 'Hello, World!');
       expect(writer.getBitsWritten(), 118);
@@ -161,126 +161,126 @@ void main() {
   group('Backwards Codec Compatibility', () {
     test('codec_string_compressed decodes correctly', () {
       final buffer = BitBuffer.fromBits([100059283527975748, 293721599081145], trueSize: 114);
-      final result = BitCodec.codec_string_compressed.reader(buffer.reader());
+      final result = BitCodec.stringCompressed.reader(buffer.reader());
 
       expect(result, 'Hello, World!');
     });
 
     test('codec_string_stepped decodes correctly', () {
       final buffer = BitBuffer.fromBits([100059283527975748, 293721599081145], trueSize: 114);
-      final result = BitCodec.codec_string_stepped.reader(buffer.reader());
+      final result = BitCodec.stringStepped.reader(buffer.reader());
 
       expect(result, 'Hello, World!');
     });
 
     test('codec_string_linear decodes correctly', () {
       final buffer = BitBuffer.fromBits([-6962012935230841020, -1982173524448681545, 17830542727], trueSize: 163);
-      final result = BitCodec.codec_string_linear.reader(buffer.reader());
+      final result = BitCodec.stringLinear.reader(buffer.reader());
 
       expect(result, 'Hello, World!');
     });
 
     test('codec_stepped_utf16 decodes correctly', () {
       final buffer = BitBuffer.fromBits([24691], trueSize: 17);
-      final result = BitCodec.codec_stepped_utf16.reader(buffer.reader());
+      final result = BitCodec.steppedUtf16.reader(buffer.reader());
 
       expect(result, 12345);
     });
 
     test('codec_string_palette decodes correctly', () {
       final buffer = BitBuffer.fromBits([6665522876794609988, -8119263838298861111, 2629752564971], trueSize: 170);
-      final result = BitCodec.codec_string_palette.reader(buffer.reader());
+      final result = BitCodec.stringPalette.reader(buffer.reader());
 
       expect(result, 'Hello, World!');
     });
 
     test('codec_int_linear_8 decodes correctly', () {
       final buffer = BitBuffer.fromBits([3959], trueSize: 12);
-      final result = BitCodec.codec_int_linear_8.reader(buffer.reader());
+      final result = BitCodec.intLinear8.reader(buffer.reader());
 
       expect(result, 123);
     });
 
     test('codec_int_linear_16 decodes correctly', () {
       final buffer = BitBuffer.fromBits([790126], trueSize: 20);
-      final result = BitCodec.codec_int_linear_16.reader(buffer.reader());
+      final result = BitCodec.intLinear16.reader(buffer.reader());
 
       expect(result, 12345);
     });
 
     test('codec_int_linear_64 decodes correctly', () {
       final buffer = BitBuffer.fromBits([31604938139], trueSize: 35);
-      final result = BitCodec.codec_int_linear_64.reader(buffer.reader());
+      final result = BitCodec.intLinear64.reader(buffer.reader());
 
       expect(result, 123456789);
     });
 
     test('codec_double_linear_8 decodes correctly', () {
       final buffer = BitBuffer.fromBits([765041063513967], trueSize: 50);
-      final result = BitCodec.codec_double_linear_8.reader(buffer.reader());
+      final result = BitCodec.doubleLinear8.reader(buffer.reader());
 
       expect(result, 123.456);
     });
 
     test('codec_double_linear_16 decodes correctly', () {
       final buffer = BitBuffer.fromBits([1530082127027919], trueSize: 51);
-      final result = BitCodec.codec_double_linear_16.reader(buffer.reader());
+      final result = BitCodec.doubleLinear16.reader(buffer.reader());
 
       expect(result, 123.456);
     });
 
     test('codec_double_linear_64 decodes correctly', () {
       final buffer = BitBuffer.fromBits([6120328508111631], trueSize: 53);
-      final result = BitCodec.codec_double_linear_64.reader(buffer.reader());
+      final result = BitCodec.doubleLinear64.reader(buffer.reader());
 
       expect(result, 123.456);
     });
 
     test('codec_list decodes correctly', () {
       final buffer = BitBuffer.fromBits([-3673361555328330108, 4014455708976232556, 17], trueSize: 134);
-      final result = BitCodec.codec_list.reader(buffer.reader());
+      final result = BitCodec.list.reader(buffer.reader());
 
       expect(result, [1, 2, 3, 'Hello']);
     });
 
     test('codec_string_map decodes correctly', () {
       final buffer = BitBuffer.fromBits([1240862530166686756, 18909578539195], trueSize: 110);
-      final result = BitCodec.codec_string_map.reader(buffer.reader());
+      final result = BitCodec.stringMap.reader(buffer.reader());
 
       expect(result, {'key': 'value'});
     });
 
     test('codec_json decodes correctly', () {
       final buffer = BitBuffer.fromBits([2481725060333373513, 37819157078390], trueSize: 111);
-      final result = BitCodec.codec_json.reader(buffer.reader());
+      final result = BitCodec.json.reader(buffer.reader());
 
       expect(result, {'key': 'value'});
     });
 
     test('codec_bool decodes correctly', () {
       final buffer = BitBuffer.fromBits([1], trueSize: 1);
-      final result = BitCodec.codec_bool.reader(buffer.reader());
+      final result = BitCodec.boolean.reader(buffer.reader());
 
       expect(result, true);
     });
 
     test('codec_json_string decodes correctly', () {
       final buffer = BitBuffer.fromBits([-6762271016373209208, -3303857246427454941, 7], trueSize: 131);
-      final result = BitCodec.codec_json_string.reader(buffer.reader());
+      final result = BitCodec.jsonString.reader(buffer.reader());
 
       expect(result, {'key': 'value'});
     });
 
     test('codec_json_string_map decodes correctly', () {
       final buffer = BitBuffer.fromBits([-6762271016373209208, -3303857246427454941, 7], trueSize: 131);
-      final result = BitCodec.codec_json_string_map.reader(buffer.reader());
+      final result = BitCodec.jsonStringMap.reader(buffer.reader());
 
       expect(result, {'key': 'value'});
     });
 
     test('codec_any decodes correctly', () {
       final buffer = BitBuffer.fromBits([4014455708976233542, 1203083669836369942, 17], trueSize: 134);
-      final result = BitCodec.codec_any.reader(buffer.reader());
+      final result = BitCodec.any.reader(buffer.reader());
 
       expect(result, 'Hello, World!');
     });

--- a/test/codec_test.dart
+++ b/test/codec_test.dart
@@ -106,7 +106,7 @@ void main() {
       final result = BitCodec.codec_list.reader(reader);
 
       expect(result, [1, 2, 3, 'Hello']);
-      expect(writer.getBitsWritten(), 134);
+      expect(writer.getBitsWritten(), 94);
     });
 
     test('codec_string_map encodes and decodes correctly', () {
@@ -114,7 +114,7 @@ void main() {
       final result = BitCodec.codec_string_map.reader(reader);
 
       expect(result, {'key': 'value'});
-      expect(writer.getBitsWritten(), 110);
+      expect(writer.getBitsWritten(), 94);
     });
 
     test('codec_json encodes and decodes correctly', () {
@@ -122,7 +122,7 @@ void main() {
       final result = BitCodec.codec_json.reader(reader);
 
       expect(result, {'key': 'value'});
-      expect(writer.getBitsWritten(), 111);
+      expect(writer.getBitsWritten(), 95);
     });
 
     test('codec_bool encodes and decodes correctly', () {
@@ -154,7 +154,7 @@ void main() {
       final result = BitCodec.codec_any.reader(reader);
 
       expect(result, 'Hello, World!');
-      expect(writer.getBitsWritten(), 134);
+      expect(writer.getBitsWritten(), 118);
     });
   });
 

--- a/test/codec_test.dart
+++ b/test/codec_test.dart
@@ -14,144 +14,144 @@ void main() {
     });
 
     test('codec_string_compressed encodes and decodes correctly', () {
-      codec_string_compressed.writer(writer, 'Hello, World!');
-      final result = codec_string_compressed.reader(reader);
+      BitCodec.codec_string_compressed.writer(writer, 'Hello, World!');
+      final result = BitCodec.codec_string_compressed.reader(reader);
 
       expect(result, 'Hello, World!');
       expect(writer.getBitsWritten(), 114);
     });
 
     test('codec_string_stepped encodes and decodes correctly', () {
-      codec_string_stepped.writer(writer, 'Hello, World!');
-      final result = codec_string_stepped.reader(reader);
+      BitCodec.codec_string_stepped.writer(writer, 'Hello, World!');
+      final result = BitCodec.codec_string_stepped.reader(reader);
 
       expect(result, 'Hello, World!');
       expect(writer.getBitsWritten(), 114);
     });
 
     test('codec_string_linear encodes and decodes correctly', () {
-      codec_string_linear.writer(writer, 'Hello, World!');
-      final result = codec_string_linear.reader(reader);
+      BitCodec.codec_string_linear.writer(writer, 'Hello, World!');
+      final result = BitCodec.codec_string_linear.reader(reader);
 
       expect(result, 'Hello, World!');
       expect(writer.getBitsWritten(), 163);
     });
 
     test('codec_stepped_utf16 encodes and decodes correctly', () {
-      codec_stepped_utf16.writer(writer, 12345);
-      final result = codec_stepped_utf16.reader(reader);
+      BitCodec.codec_stepped_utf16.writer(writer, 12345);
+      final result = BitCodec.codec_stepped_utf16.reader(reader);
 
       expect(result, 12345);
       expect(writer.getBitsWritten(), 17);
     });
 
     test('codec_string_palette encodes and decodes correctly', () {
-      codec_string_palette.writer(writer, 'Hello, World!');
-      final result = codec_string_palette.reader(reader);
+      BitCodec.codec_string_palette.writer(writer, 'Hello, World!');
+      final result = BitCodec.codec_string_palette.reader(reader);
 
       expect(result, 'Hello, World!');
       expect(writer.getBitsWritten(), 170);
     });
 
     test('codec_int_linear_8 encodes and decodes correctly', () {
-      codec_int_linear_8.writer(writer, 123);
-      final result = codec_int_linear_8.reader(reader);
+      BitCodec.codec_int_linear_8.writer(writer, 123);
+      final result = BitCodec.codec_int_linear_8.reader(reader);
 
       expect(result, 123);
       expect(writer.getBitsWritten(), 12);
     });
 
     test('codec_int_linear_16 encodes and decodes correctly', () {
-      codec_int_linear_16.writer(writer, 12345);
-      final result = codec_int_linear_16.reader(reader);
+      BitCodec.codec_int_linear_16.writer(writer, 12345);
+      final result = BitCodec.codec_int_linear_16.reader(reader);
 
       expect(result, 12345);
       expect(writer.getBitsWritten(), 20);
     });
 
     test('codec_int_linear_64 encodes and decodes correctly', () {
-      codec_int_linear_64.writer(writer, 123456789);
-      final result = codec_int_linear_64.reader(reader);
+      BitCodec.codec_int_linear_64.writer(writer, 123456789);
+      final result = BitCodec.codec_int_linear_64.reader(reader);
 
       expect(result, 123456789);
       expect(writer.getBitsWritten(), 35);
     });
 
     test('codec_double_linear_8 encodes and decodes correctly', () {
-      codec_double_linear_8.writer(writer, 123.456);
-      final result = codec_double_linear_8.reader(reader);
+      BitCodec.codec_double_linear_8.writer(writer, 123.456);
+      final result = BitCodec.codec_double_linear_8.reader(reader);
 
       expect(result, 123.456);
       expect(writer.getBitsWritten(), 50);
     });
 
     test('codec_double_linear_16 encodes and decodes correctly', () {
-      codec_double_linear_16.writer(writer, 123.456);
-      final result = codec_double_linear_16.reader(reader);
+      BitCodec.codec_double_linear_16.writer(writer, 123.456);
+      final result = BitCodec.codec_double_linear_16.reader(reader);
 
       expect(result, 123.456);
       expect(writer.getBitsWritten(), 51);
     });
 
     test('codec_double_linear_64 encodes and decodes correctly', () {
-      codec_double_linear_64.writer(writer, 123.456);
-      final result = codec_double_linear_64.reader(reader);
+      BitCodec.codec_double_linear_64.writer(writer, 123.456);
+      final result = BitCodec.codec_double_linear_64.reader(reader);
 
       expect(result, 123.456);
       expect(writer.getBitsWritten(), 53);
     });
 
     test('codec_list encodes and decodes correctly', () {
-      codec_list.writer(writer, [1, 2, 3, 'Hello']);
-      final result = codec_list.reader(reader);
+      BitCodec.codec_list.writer(writer, [1, 2, 3, 'Hello']);
+      final result = BitCodec.codec_list.reader(reader);
 
       expect(result, [1, 2, 3, 'Hello']);
       expect(writer.getBitsWritten(), 134);
     });
 
     test('codec_string_map encodes and decodes correctly', () {
-      codec_string_map.writer(writer, {'key': 'value'});
-      final result = codec_string_map.reader(reader);
+      BitCodec.codec_string_map.writer(writer, {'key': 'value'});
+      final result = BitCodec.codec_string_map.reader(reader);
 
       expect(result, {'key': 'value'});
       expect(writer.getBitsWritten(), 110);
     });
 
     test('codec_json encodes and decodes correctly', () {
-      codec_json.writer(writer, {'key': 'value'});
-      final result = codec_json.reader(reader);
+      BitCodec.codec_json.writer(writer, {'key': 'value'});
+      final result = BitCodec.codec_json.reader(reader);
 
       expect(result, {'key': 'value'});
       expect(writer.getBitsWritten(), 111);
     });
 
     test('codec_bool encodes and decodes correctly', () {
-      codec_bool.writer(writer, true);
-      final result = codec_bool.reader(reader);
+      BitCodec.codec_bool.writer(writer, true);
+      final result = BitCodec.codec_bool.reader(reader);
 
       expect(result, true);
       expect(writer.getBitsWritten(), 1);
     });
 
     test('codec_json_string encodes and decodes correctly', () {
-      codec_json_string.writer(writer, {'key': 'value'});
-      final result = codec_json_string.reader(reader);
+      BitCodec.codec_json_string.writer(writer, {'key': 'value'});
+      final result = BitCodec.codec_json_string.reader(reader);
 
       expect(result, {'key': 'value'});
       expect(writer.getBitsWritten(), 131);
     });
 
     test('codec_json_string_map encodes and decodes correctly', () {
-      codec_json_string_map.writer(writer, {'key': 'value'});
-      final result = codec_json_string_map.reader(reader);
+      BitCodec.codec_json_string_map.writer(writer, {'key': 'value'});
+      final result = BitCodec.codec_json_string_map.reader(reader);
 
       expect(result, {'key': 'value'});
       expect(writer.getBitsWritten(), 131);
     });
 
     test('codec_any encodes and decodes correctly', () {
-      codec_any.writer(writer, 'Hello, World!');
-      final result = codec_any.reader(reader);
+      BitCodec.codec_any.writer(writer, 'Hello, World!');
+      final result = BitCodec.codec_any.reader(reader);
 
       expect(result, 'Hello, World!');
       expect(writer.getBitsWritten(), 134);


### PR DESCRIPTION
This pull request includes several changes to add a new GitHub Actions workflow, update dependencies, and improve test coverage for Codecs. The most important changes include adding a coverage workflow, adding missing dev-decencie, and adding new tests for various `BitCodec` methods.

### Dependency Updates:
* [`pubspec.yaml`](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25R5-R14): Updated the `dev_dependencies` to include missing `flutter_lints`.

### Code Changes:
* Modified the `BitCodec` instantiation to use `SimpleBitCodec` to enable const Objects for `SimpleBitCodec` and `BestBitCodec`.

### Test Codecs:
* [`test/codec_test.dart`](diffhunk://#diff-684efc0d256ab3ddd1594d81bd616856d6a9813b27efd305c7726305f7c11911R1-R288): Added tests for various `BitCodec` methods to ensure correct encoding and decoding of different data types, including strings, integers, doubles, lists, maps, JSON, and booleans. This also includes tests for backwards compatibility with older codec versions.

### GitHub Actions Workflow:
* [`.github/workflows/coverage.yml`](diffhunk://#diff-a2115d277b5ca5a2f09a999e53440839cf332b94da177f3d1766334555b0f7c6R1-R31): Suggest adding a GitHub Actions workflow to run tests and upload coverage reports to Codecov. This includes steps for checking out the repository, setting up Dart, installing dependencies, analyzing the project, and running tests with coverage. _Coverage requires a secrets token configured._